### PR TITLE
Removed the > character from cp env example

### DIFF
--- a/developers/the-factory/create-a-release.md
+++ b/developers/the-factory/create-a-release.md
@@ -25,7 +25,7 @@ To create a release you need to deploy a version of our [Factory contract](https
 1. `git clone` [`https://github.com/simpleweb/whitelabel-starter.git`](https://github.com/simpleweb/whitelabel-starter.git)``
 2. `cd whitelabel-starter`
 3. `yarn install`` `**`OR`**` ``npm install`
-4. `cp .env.example > .env`&#x20;
+4. `cp .env.example .env`
 5. Open the project in your favourite code editor. We recommend [Visual Studio Code](https://code.visualstudio.com).
 
 ### Environment Setup


### PR DESCRIPTION
This change fixes the example cp command to create a .env file from the included .env.example file within the open-format-starter project.

**Before**
<img width="689" alt="Screenshot 2022-05-05 at 16 26 48" src="https://user-images.githubusercontent.com/2954283/166958050-b1437425-c293-4686-8968-5187cb79d4af.png">


**After**
<img width="696" alt="Screenshot 2022-05-05 at 16 26 01" src="https://user-images.githubusercontent.com/2954283/166957913-2ef2c795-405d-4bc4-a69b-42e20fcdd848.png">

